### PR TITLE
Fix duration extraction and small issues with the installation docs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,83 +3,83 @@
 History
 -------
 
-0.1.22 (2018-04-28)
+0.1.22 (2019-04-28)
 +++++++++++++++++++
 
 * Use proper time field for chaptermark start instead of char
 * Improved test coverage
 * Improved video dimension handling for handbrake generated portrait videos
 
-0.1.21 (2018-04-24)
+0.1.21 (2019-04-24)
 +++++++++++++++++++
 
 * Fixed package dependencies
 * Better release docs
 
-0.1.20 (2018-04-24)
+0.1.20 (2019-04-24)
 +++++++++++++++++++
 
 * Fixed version history
 * Better release docs
 
-0.1.19 (2018-04-24)
+0.1.19 (2019-04-24)
 +++++++++++++++++++
 
 * Added fulltext search
 * Added filtering by date + some faceted navigation support
 * use overwritable template block for feeds section (could be used for podlove subscribe button)
 
-0.1.18 (2018-04-18)
+0.1.18 (2019-04-18)
 +++++++++++++++++++
 
 * Fixed broken update view due to empty chaptermarks + test
 * Fixed two image/video javascript bugs
 
-0.1.17 (2018-04-15)
+0.1.17 (2019-04-15)
 +++++++++++++++++++
 
 * Added chaptermarks feature
 * Duration is now displayed correctly in podlove player
 * If an audio upload succeeded, add the uploaded element to podcast audio select form
 
-0.1.16 (2018-03-23)
+0.1.16 (2019-03-23)
 +++++++++++++++++++
 
 * Finally, rtfd is working again, including screencast
 
-0.1.15 (2018-03-23)
+0.1.15 (2019-03-23)
 +++++++++++++++++++
 
 * Trying again... rtfd still failing
 
-0.1.14 (2018-03-23)
+0.1.14 (2019-03-23)
 +++++++++++++++++++
 
 * Added rtfd configuration file to be able to use python 3 :/
 
-0.1.13 (2018-03-22)
+0.1.13 (2019-03-22)
 +++++++++++++++++++
 
 * Release to update read the docs
 
-0.1.12 (2018-03-22)
+0.1.12 (2019-03-22)
 +++++++++++++++++++
 
 * Improved installation documentation
 
-0.1.11 (2018-03-21)
+0.1.11 (2019-03-21)
 +++++++++++++++++++
 
 * Fixed requirements for package
 
-0.1.10 (2018-03-21)
+0.1.10 (2019-03-21)
 +++++++++++++++++++
 
 * Dont limit the number of items in feed (was 5 items)
 * Workaround for ogg files (ending differs for Audio model field name)
 * Added opus format to Audio model
 
-0.1.9 (2018-03-12)
+0.1.9 (2019-03-12)
 ++++++++++++++++++
 
 * Added some podcast specific fields to post edit form
@@ -87,18 +87,18 @@ History
 * Added audio file support for post edit form
 * Show which audio files already were uploaded
 
-0.1.8 (2018-02-28)
+0.1.8 (2019-02-28)
 ++++++++++++++++++
 
 * Added support for m4v and improved dimension detection for iOS videos
 * Added some tests for different video sources
 
-0.1.7 (2018-02-28)
+0.1.7 (2019-02-28)
 ++++++++++++++++++
 
 * forgot linting
 
-0.1.6 (2018-02-28)
+0.1.6 (2019-02-28)
 ++++++++++++++++++
 
 * Use filepond for media uploads (images video)

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ Add django-cast and some dependencies to your ``INSTALLED_APPS``:
         "imagekit",
         "ckeditor",
         "ckeditor_uploader",
+        "rest_framework",
         "rest_framework.authtoken",
         "filepond.apps.FilepondConfig",
         "cast.apps.CastConfig",

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ Add Django Cast's URL patterns:
         # Uploads
         path("uploads/", include("filepond.urls", namespace="filepond")),
         # Cast
-        path("/cast", include("cast.urls", namespace="cast")),
+        path("cast/", include("cast.urls", namespace="cast")),
         ...
     ]
 

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Add django-cast and some dependencies to your ``INSTALLED_APPS``:
         "rest_framework.authtoken",
         "filepond.apps.FilepondConfig",
         "cast.apps.CastConfig",
+        "watson",
         ...
     )
 

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Add Django Cast's URL patterns:
 
 .. code-block:: python
 
-    from django.urls import path
+    from django.urls import path, include
 
     from rest_framework.documentation import include_docs_urls
     from rest_framework.authtoken import views as authtokenviews

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,8 @@ Add django-cast and some dependencies to your ``INSTALLED_APPS``:
         ...
         "imagekit",
         "ckeditor",
-        "ckeditor_uploader",
+        "ckeditor_uploader"
+        "crispy_forms",
         "rest_framework",
         "rest_framework.authtoken",
         "filepond.apps.FilepondConfig",

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ Add django-cast and some dependencies to your ``INSTALLED_APPS``:
         "ckeditor",
         "ckeditor_uploader"
         "crispy_forms",
+        "django_filters",
         "rest_framework",
         "rest_framework.authtoken",
         "filepond.apps.FilepondConfig",

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,10 @@ django-filter
 # search / filter forms
 django-crispy-forms
 
+# API
+coreapi
+djangorestframework
+
 # slugs
 python-slugify
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -23,7 +23,7 @@ pytest-django
 python-slugify
 
 django-ckeditor
-
+django-filepond
 django-imagekit
 
 coreapi

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     packages=["cast"],
     include_package_data=True,
     install_requires=[
+        "coreapi",
         "Pillow",
         "django-model-utils",
         "django-ckeditor",
@@ -62,6 +63,7 @@ setup(
         "django-watson",
         "django-filter",
         "django-filepond",
+        "djangorestframework",
         "python-slugify",
     ],
     license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "Pillow",
         "django-model-utils",
         "django-ckeditor",
+        "django-crispy-forms",
         "django-imagekit",
         "django-watson",
         "django-filter",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import pytest
 
 
@@ -93,12 +95,7 @@ class TestAudioModel:
     @pytest.mark.django_db
     def test_audio_duration(self, audio):
         duration = audio._get_audio_duration(audio.m4a.path)
-        assert duration == "00:00:00.70"
-
-    @pytest.mark.django_db
-    def test_audio_duration_none(self, audio):
-        duration = audio._lines_to_duration([])
-        assert duration is None
+        assert duration == timedelta(microseconds=700000)
 
     @pytest.mark.django_db
     def test_audio_create_duration(self, audio):


### PR DESCRIPTION
Thank you very much for writing this library.

While setting up a local copy I noticed that lots of dependencies were left out from either setup.py or the installation docs. 

Additionally, Django crashed during audio file uploads because the duration was being passed as string into the DurationField.